### PR TITLE
Fixes challenge decoding in cases the inlined json has no white space

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -55,9 +55,11 @@ export default class FritzBoxAPI {
 				.get(this.api('/'))
 				.end((error, {text} = {}) => {
 					// get challenge
-					const valueStart = text.indexOf('"challenge": ') + 14;
-					const valueEnd = text.indexOf('",', valueStart);
-					const challenge = text.substring(valueStart, valueEnd);
+					const matches = text.match(/"challenge":\s*"(.+?)",/);
+					const challenge = matches ? matches[1] : null;
+					if (!challenge) {
+						return reject(new Error('Unable to decode challenge'));
+					}
 
 					// solve challenge
 					const response = `${challenge}-${md5(`${challenge}-${reduceString(password)}`)}`;


### PR DESCRIPTION
For FRITZ!Box Fon WLAN 7360 and FRITZ!OS 06.80 it happened to be the case that the inlined data json had no whitespace to separate keys from their values ("challenge": ".." vs. "challenge":".."). This commit should fix the issue while being backwards compatible.